### PR TITLE
Fix docker for dan's CentOS7 build

### DIFF
--- a/hostnames.sh
+++ b/hostnames.sh
@@ -35,7 +35,7 @@ chmod 600 /root/.ssh/authorized_keys
 
 # TERM needs to be set for the installer
 echo "export TERM=xterm" >> /root/.bashrc
-echo "export TEMR=xterm" >> /home/vagrant/.bashrc
+echo "export TERM=xterm" >> /home/vagrant/.bashrc
 
 # GO support
 mkdir -p /home/vagrant/go

--- a/hostnames.sh
+++ b/hostnames.sh
@@ -75,9 +75,10 @@ echo "::1       localhost localhost.localdomain localhost6 localhost6.localdomai
 groupadd docker
 usermod -aG docker vagrant
 
-yum install -y docker
+#Later docker packages on redhat break UGE Docker implementation
+yum install -y docker-1.10.3-44.el7.centos
 
-echo "DOCKER_STORAGE_OPTIONS=--storage-opt dm.no_warn_on_loop_devices=true" > /etc/sysconfig/docker-storage
+#echo "DOCKER_STORAGE_OPTIONS=--storage-opt dm.no_warn_on_loop_devices=true" > /etc/sysconfig/docker-storage
 
 service docker start
 

--- a/installation.sh
+++ b/installation.sh
@@ -69,8 +69,8 @@ yum install -y gcc
 
 # EPEL package support installation
 cd 
-wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm 
-rpm -ivh epel-release-6-8.noarch.rpm
+wget http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
+rpm -ivh epel-release-7-8.noarch.rpm
 
 # GOLANG support 
 yum install -y golang


### PR DESCRIPTION
Newer releases of docker are breaking CentOS7 builds unless we revert to a known good earlier version (see also Univa support ticket #15264)
Currently the build breaks for docker integration without these fixes
This PR does not pin versions in yum.conf , so a yum update would break docker support until the centos docker package is fixed.
